### PR TITLE
fix(security): keep community provider API key server-side (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build
+      - name: Scan client bundle for secrets
+        run: npm run check:bundle
       - uses: actions/upload-artifact@v4
         with:
           name: build-artifacts

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "audit:fix": "npm audit fix --force",
     "audit:check": "npm audit --audit-level high --production",
     "deploy:vercel": "vercel --prod",
-    "deploy:preview": "vercel"
+    "deploy:preview": "vercel",
+    "check:bundle": "node scripts/check-client-bundle.mjs"
   },
   "keywords": [
     "word-search",

--- a/scripts/check-client-bundle.mjs
+++ b/scripts/check-client-bundle.mjs
@@ -1,0 +1,47 @@
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const SECRET_PATTERNS = [
+  [/sk-or-v1-[A-Za-z0-9_-]{16,}/, 'OpenRouter key'],
+  [/sk-ant-[A-Za-z0-9_-]{16,}/, 'Anthropic key'],
+  [/\bsk-[A-Za-z0-9_-]{32,}\b/, 'OpenAI-style key'],
+  [/AIza[0-9A-Za-z_-]{30,}/, 'Google API key'],
+  [/ghp_[A-Za-z0-9]{30,}/, 'GitHub PAT'],
+  [/xox[baprs]-[A-Za-z0-9-]{10,}/, 'Slack token'],
+];
+
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+const distDir = path.resolve('dist');
+let hits = 0;
+try {
+  for await (const file of walk(distDir)) {
+    if (!/\.(js|html|css|mjs)$/.test(file)) continue;
+    const content = await readFile(file, 'utf8').catch(() => '');
+    for (const [pattern, label] of SECRET_PATTERNS) {
+      const match = content.match(pattern);
+      if (match) {
+        console.error(`[check:bundle] LEAK (${label}) in ${file}: ${match[0].slice(0, 12)}...`);
+        hits += 1;
+      }
+    }
+  }
+} catch (err) {
+  if (err.code === 'ENOENT') {
+    console.error('[check:bundle] dist/ not found — run `npm run build` first.');
+    process.exit(1);
+  }
+  throw err;
+}
+
+if (hits > 0) {
+  console.error(`[check:bundle] FAILED — ${hits} potential secret(s) found in client bundle.`);
+  process.exit(1);
+}
+console.log('[check:bundle] OK — no secrets detected in client bundle.');

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -71,11 +71,11 @@ async function generateWithOpenAICompatibleAPI(
     const messages = getOpenAIGameGenerationMessages({ theme, wordCount, levelCount, language });
     onLog(createLogEntry(`PROVIDER: ${settings.providerName} (OpenAI-Compatible)\nENDPOINT: ${settings.baseURL}\nMODEL: ${settings.modelName}\nMESSAGES:\n${JSON.stringify(messages, null, 2)}`, AILogType.Request));
 
-    // Use the LLM proxy only if it's enabled AND we are using the community provider
-    const isCommunityProvider = settings.apiKey === process.env.API_KEY;
-    const useProxy = process.env.USE_LLM_PROXY === 'true' && isCommunityProvider;
+    // Route through the server-side proxy only when the caller opted in
+    // (community provider). BYO credentials always go direct.
+    const useProxy = settings.useProxy === true;
     const proxyUrl = process.env.LLM_PROXY_URL || '/api/llm-proxy';
-    
+
   let response;
   try {
     if (useProxy) {
@@ -188,15 +188,14 @@ export async function generateGameLevels(
       }
       settingsToUse = effectiveByollmSettings;
     } else {
-      // Use Community Provider (OpenRouter)
-      if (!process.env.API_KEY) {
-        throw new Error("Community provider (OpenRouter) is not configured. Please add an API_KEY to environment variables or use your own LLM in Settings.");
-      }
+      // Community provider (OpenRouter). Routed through the server-side proxy
+      // so the shared key never reaches the client bundle.
       settingsToUse = {
         providerName: 'Community (OpenRouter)',
-        apiKey: process.env.API_KEY,
+        apiKey: '',
         baseURL: 'https://openrouter.ai/api/v1',
         modelName: aiSettings.communityModel || process.env.COMMUNITY_MODEL_NAME || 'google/gemini-2.5-flash:free',
+        useProxy: true,
       };
     }
     
@@ -210,8 +209,8 @@ export async function generateGameLevels(
 }
 
 export async function testAIConnection(settings: BYOLLMSettings): Promise<void> {
-    if (!settings.apiKey || !settings.baseURL || !settings.modelName) {
-        throw new Error("API Key, Base URL, and Model Name are all required.");
+    if (!settings.baseURL || !settings.modelName || (settings.useProxy !== true && !settings.apiKey)) {
+        throw new Error("Base URL and Model Name are required. API Key is also required for direct (non-proxy) connections.");
     }
 
     const testPayload = {
@@ -221,9 +220,9 @@ export async function testAIConnection(settings: BYOLLMSettings): Promise<void> 
         stream: false,
     };
 
-    // Use the proxy only if it's enabled AND we are using the community provider
-    const isCommunityProvider = settings.apiKey === process.env.API_KEY;
-    const useProxy = process.env.USE_LLM_PROXY === 'true' && isCommunityProvider;
+    // Route through the server-side proxy only when the caller opted in
+    // (community provider). BYO credentials always go direct.
+    const useProxy = settings.useProxy === true;
     const proxyUrl = process.env.LLM_PROXY_URL || '/api/llm-proxy';
     
   let response;

--- a/test/services/geminiService.test.ts
+++ b/test/services/geminiService.test.ts
@@ -134,10 +134,7 @@ describe('GeminiService', () => {
       );
     });
 
-    it('should use proxy when USE_LLM_PROXY is true', async () => {
-      // Temporarily override environment variable
-      const originalUseProxy = process.env.USE_LLM_PROXY;
-      process.env.USE_LLM_PROXY = 'true';
+    it('should route community provider through the proxy', async () => {
 
       const mockResponse = {
         ok: true,
@@ -185,8 +182,6 @@ describe('GeminiService', () => {
         })
       );
 
-      // Restore original value
-      process.env.USE_LLM_PROXY = originalUseProxy;
     });
 
     it('should handle API errors gracefully', async () => {
@@ -644,14 +639,51 @@ describe('GeminiService', () => {
       await expect(testAIConnection(settings)).resolves.toBeUndefined();
     });
 
-    it('should throw error for missing required fields', async () => {
+    it('should throw error for missing required fields (direct connection)', async () => {
       const incompleteSettings: Partial<BYOLLMSettings> = {
         providerName: 'Test Provider',
         // Missing apiKey, baseURL, modelName
       };
 
       await expect(testAIConnection(incompleteSettings as BYOLLMSettings))
-        .rejects.toThrow('API Key, Base URL, and Model Name are all required.');
+        .rejects.toThrow('Base URL and Model Name are required. API Key is also required for direct (non-proxy) connections.');
+    });
+
+    it('should allow proxy connections without an API key (community provider)', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: 'Hello!' } }]
+        })
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const settings: BYOLLMSettings = {
+        providerName: 'Community Provider',
+        apiKey: '',
+        baseURL: 'https://openrouter.ai/api/v1',
+        modelName: 'google/gemini-2.5-flash',
+        useProxy: true
+      };
+
+      await expect(testAIConnection(settings)).resolves.toBeUndefined();
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/llm-proxy',
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+
+    it('should still require API key for direct connections', async () => {
+      const settings: BYOLLMSettings = {
+        providerName: 'Test Provider',
+        apiKey: '',
+        baseURL: 'https://api.test.com/v1',
+        modelName: 'test-model',
+        useProxy: false
+      };
+
+      await expect(testAIConnection(settings))
+        .rejects.toThrow('API Key is also required for direct');
     });
 
     it('should handle API errors in connection test', async () => {
@@ -689,10 +721,7 @@ describe('GeminiService', () => {
         .rejects.toThrow('Network error during connection test: Network error');
     });
 
-    it('should NOT use proxy for custom providers even if USE_LLM_PROXY is true', async () => {
-      const originalUseProxy = process.env.USE_LLM_PROXY;
-      process.env.USE_LLM_PROXY = 'true';
-
+    it('should NEVER use proxy for user-supplied BYO providers', async () => {
       const mockResponse = {
         ok: true,
         json: () => Promise.resolve({
@@ -706,9 +735,10 @@ describe('GeminiService', () => {
 
       const settings: BYOLLMSettings = {
         providerName: 'Test Provider',
-        apiKey: 'a-custom-user-key', // Not the community key
+        apiKey: 'a-custom-user-key',
         baseURL: 'https://api.test.com/v1',
-        modelName: 'test-model'
+        modelName: 'test-model',
+        useProxy: false
       };
 
       await testAIConnection(settings);
@@ -723,46 +753,32 @@ describe('GeminiService', () => {
           })
         })
       );
-
-      process.env.USE_LLM_PROXY = originalUseProxy;
     });
 
-    it('should use proxy for community provider when USE_LLM_PROXY is true', async () => {
-      const originalUseProxy = process.env.USE_LLM_PROXY;
-      const originalApiKey = process.env.API_KEY;
-      process.env.USE_LLM_PROXY = 'true';
-      process.env.API_KEY = 'community-key'; // This is the community key
-
+    it('should route community provider through proxy in connection test', async () => {
       const mockResponse = {
         ok: true,
         json: () => Promise.resolve({
-          choices: [{
-            message: { content: 'Hello!' }
-          }]
+          choices: [{ message: { content: 'Hello!' } }]
         })
       };
 
       global.fetch = vi.fn().mockResolvedValue(mockResponse);
 
       const settings: BYOLLMSettings = {
-        providerName: 'Community Provider',
-        apiKey: 'community-key', // Matching the community key
+        providerName: 'Community (OpenRouter)',
+        apiKey: '',
         baseURL: 'https://openrouter.ai/api/v1',
-        modelName: 'google/gemini-2.5-flash'
+        modelName: 'google/gemini-2.5-flash:free',
+        useProxy: true
       };
 
       await testAIConnection(settings);
 
-      // Should use the proxy
       expect(fetch).toHaveBeenCalledWith(
         '/api/llm-proxy',
-        expect.objectContaining({
-          method: 'POST'
-        })
+        expect.objectContaining({ method: 'POST' })
       );
-
-      process.env.USE_LLM_PROXY = originalUseProxy;
-      process.env.API_KEY = originalApiKey;
     });
 
     // Test for empty response from API

--- a/types.ts
+++ b/types.ts
@@ -82,6 +82,10 @@ export interface BYOLLMSettings {
   apiKey: string;
   baseURL: string;
   modelName: string;
+  /** Route this request through the server-side LLM proxy instead of
+   *  calling the provider directly. Required (and set automatically) for
+   *  the shared community provider so its API key stays server-side. */
+  useProxy?: boolean;
 }
 
 export interface AIProviderSettings {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,11 +6,12 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      // Security: API_KEY must NEVER appear here. It is a server-side secret
+      // consumed only by /api/llm-proxy at runtime on Vercel. Community
+      // provider requests are always routed through the proxy.
       define: {
-        'process.env.API_KEY': JSON.stringify(env.API_KEY),
         'process.env.COMMUNITY_MODEL_NAME': JSON.stringify(env.COMMUNITY_MODEL_NAME),
         'process.env.LANGUAGE_MODEL_MAP': JSON.stringify(env.LANGUAGE_MODEL_MAP),
-        'process.env.USE_LLM_PROXY': JSON.stringify(env.USE_LLM_PROXY),
         'process.env.LLM_PROXY_URL': JSON.stringify(env.LLM_PROXY_URL)
       },
       resolve: {


### PR DESCRIPTION
## Problem
The community provider's OpenRouter `API_KEY` was embedded into the client bundle via Vite `define` and compared client-side (`settings.apiKey === process.env.API_KEY`) to decide proxy routing. Anyone could read the key from the deployed JS.

## Fix
- Dropped `API_KEY`/`USE_LLM_PROXY` from Vite defines — key stays server-side (only `api/llm-proxy` reads it at runtime).
- Proxy routing now uses an explicit `useProxy` flag on `BYOLLMSettings`, set automatically for the community provider.
- `testAIConnection` requires apiKey only for direct calls.
- New `npm run check:bundle` secret scanner (OpenRouter/OpenAI/Anthropic/Google/GitHub/Slack patterns) wired into CI after build — verified it exits non-zero on a planted leak.

## Verification
- type-check ✅ · lint 0 errors ✅ · tests 244/244 ✅ · build ✅ · bundle scan ✅
- Negative-tested scanner with planted fake key → correctly fails

Closes #16