### PR TITLE
feat: Vercel KV-backed rate limiter (#19)

### DIFF
--- a/api/llm-proxy/config.ts
+++ b/api/llm-proxy/config.ts
@@ -1,0 +1,16 @@
+// Server-side configuration for the LLM proxy. Centralized here so the
+// rate limit, model allowlist, and request validation can all read from
+// the same source of truth and the values can be overridden by env vars
+// without each module re-implementing the lookup.
+
+export const RATE_LIMIT_WINDOW_MS: number = (() => {
+  const raw = process.env.RATE_LIMIT_WINDOW_MS;
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : 60_000;
+})();
+
+export const RATE_LIMIT_MAX_REQUESTS: number = (() => {
+  const raw = process.env.RATE_LIMIT_MAX_REQUESTS;
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : 15;
+})();

--- a/api/llm-proxy/index.ts
+++ b/api/llm-proxy/index.ts
@@ -3,11 +3,7 @@
 
 import { buildAllowedModels, checkModelPermission } from './models';
 import { validateProxyRequest } from './validate';
-
-// Rate limiting (in-memory, per-edge-instance)
-const rateLimits = new Map<string, { count: number; resetTime: number }>();
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
-const RATE_LIMIT_MAX_REQUESTS = 15; // requests per window per IP
+import { checkRateLimit, formatRateLimitHeaders } from './rateLimit';
 
 function getClientIP(request: Request): string {
   // Vercel forwards the real IP in headers
@@ -20,30 +16,6 @@ function getClientIP(request: Request): string {
     return realIP.trim();
   }
   return 'unknown';
-}
-
-function checkRateLimit(ip: string): { allowed: boolean; remaining: number; resetIn: number } {
-  const now = Date.now();
-  const entry = rateLimits.get(ip);
-  if (!entry || now > entry.resetTime) {
-    rateLimits.set(ip, { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS });
-    return { allowed: true, remaining: RATE_LIMIT_MAX_REQUESTS - 1, resetIn: RATE_LIMIT_WINDOW_MS };
-  }
-  if (entry.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return { allowed: false, remaining: 0, resetIn: entry.resetTime - now };
-  }
-  entry.count++;
-  return { allowed: true, remaining: RATE_LIMIT_MAX_REQUESTS - entry.count, resetIn: entry.resetTime - now };
-}
-
-// Cleanup old entries periodically (prevent memory leak)
-function cleanupRateLimits(): void {
-  const now = Date.now();
-  for (const [ip, entry] of rateLimits) {
-    if (now > entry.resetTime) {
-      rateLimits.delete(ip);
-    }
-  }
 }
 
 const ALLOWED_ORIGINS = [
@@ -185,9 +157,7 @@ export async function POST(request: Request) {
   try {
     // Check rate limit first
     const clientIP = getClientIP(request);
-    const rateLimitResult = checkRateLimit(clientIP);
-    // Periodic cleanup
-    cleanupRateLimits();
+    const rateLimitResult = await checkRateLimit(clientIP);
     if (!rateLimitResult.allowed) {
       return new Response(
         JSON.stringify({ error: 'Rate limit exceeded. Please try again later.' }),
@@ -196,7 +166,7 @@ export async function POST(request: Request) {
           headers: {
             'Content-Type': 'application/json',
             'Access-Control-Allow-Origin': getAllowedOrigin(request),
-            'Retry-After': String(Math.ceil(rateLimitResult.resetIn / 1000)),
+            ...formatRateLimitHeaders(rateLimitResult),
           },
         }
       );

--- a/api/llm-proxy/index.ts
+++ b/api/llm-proxy/index.ts
@@ -2,8 +2,8 @@
 // This is a standalone TypeScript version that doesn't depend on Next.js
 
 import { buildAllowedModels, checkModelPermission } from './models';
-import { validateProxyRequest } from './validate';
 import { checkRateLimit, formatRateLimitHeaders } from './rateLimit';
+import { validateProxyRequest } from './validate';
 
 function getClientIP(request: Request): string {
   // Vercel forwards the real IP in headers
@@ -47,13 +47,6 @@ function getAllowedOrigin(request: Request): string {
   return 'https://llm-wordsearch.vercel.app';
 }
 
-interface LLMProxyRequest {
-  model: string;
-  messages: Array<{ role: string; content: string }>;
-  max_tokens?: number;
-  stream?: boolean;
-  response_format?: { type: string };
-}
 
 interface LLMProxyResponse {
   choices: Array<{

--- a/api/llm-proxy/rateLimit.ts
+++ b/api/llm-proxy/rateLimit.ts
@@ -1,0 +1,46 @@
+// Vercel KV-backed distributed rate limiting for the LLM proxy.
+// Replaces the previous in-memory Map which was per-instance and reset
+// on every cold start — effectively a no-op for adversarial traffic.
+
+import { kv } from '@vercel/kv';
+
+const WINDOW_SECONDS = 60;
+const MAX_REQUESTS = 15;
+
+export interface RateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  resetIn: number; // milliseconds until the window resets
+}
+
+// Pure formatter — kept as a free function so it can be unit-tested
+// without importing the @vercel/kv module at all.
+export function formatRateLimitHeaders(result: RateLimitResult): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(MAX_REQUESTS),
+    'X-RateLimit-Remaining': String(Math.max(0, result.remaining)),
+    'Retry-After': String(Math.ceil(result.resetIn / 1000)),
+  };
+}
+
+export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
+  const key = `ratelimit:llm-proxy:${ip}`;
+  // Atomic INCR; KV returns the new value. EXPIRE only on the first hit
+  // of the window so subsequent calls don't push the reset out.
+  const pipeline = kv.multi();
+  pipeline.incr(key);
+  pipeline.ttl(key);
+  const replies = (await pipeline.exec()) as [number | null, number | null];
+
+  const count = typeof replies[0] === 'number' ? replies[0] : 0;
+  let ttl = typeof replies[1] === 'number' ? replies[1] : -1;
+
+  if (count === 1 || ttl < 0) {
+    await kv.expire(key, WINDOW_SECONDS);
+    ttl = WINDOW_SECONDS;
+  }
+
+  const remaining = Math.max(0, MAX_REQUESTS - count);
+  const allowed = count <= MAX_REQUESTS;
+  return { allowed, remaining, resetIn: ttl * 1000 };
+}

--- a/api/llm-proxy/rateLimit.ts
+++ b/api/llm-proxy/rateLimit.ts
@@ -1,46 +1,97 @@
-// Vercel KV-backed distributed rate limiting for the LLM proxy.
-// Replaces the previous in-memory Map which was per-instance and reset
-// on every cold start — effectively a no-op for adversarial traffic.
+// Server-side rate limit for the LLM proxy, backed by Vercel KV.
+//
+// Why KV: the proxy is a Vercel Edge Function. Cold starts spin up new
+// instances and individual requests are routed arbitrarily, so an in-process
+// Map is shared only by requests that happen to land on the same isolate for
+// the same lifetime. KV gives us a single counter per IP that survives across
+// instances and across cold starts.
+//
+// Algorithm: fixed-window counter.
+//   key   = "rl:<ip>"
+//   count = INCR key                       (returns new value, atomic)
+//   if count == 1: EXPIRE key  windowMs    (set TTL on first hit only)
+//   ttl   = PTTL key                       (ms remaining; -1 = no TTL,
+//                                           -2 = key missing)
+//   allowed  = count <= maxRequests
+//   remaining = max(0, maxRequests - count)
+//   resetIn  = max(0, ttl)
+//
+// We pipeline the EXPIRE behind the INCR so the network round-trip cost is
+// at most one extra command on the first hit in each window. The TTL is
+// only set on the first hit so subsequent INCRs don't keep extending the
+// reset (which would be a sliding window in disguise and would weaken the
+// cap). PTTL is read separately because the pipeline return value already
+// gives us the new count.
 
 import { kv } from '@vercel/kv';
 
-const WINDOW_SECONDS = 60;
-const MAX_REQUESTS = 15;
+import {
+  RATE_LIMIT_MAX_REQUESTS,
+  RATE_LIMIT_WINDOW_MS,
+} from './config';
 
 export interface RateLimitResult {
   allowed: boolean;
   remaining: number;
-  resetIn: number; // milliseconds until the window resets
+  resetIn: number;
+  limit: number;
 }
 
-// Pure formatter — kept as a free function so it can be unit-tested
-// without importing the @vercel/kv module at all.
-export function formatRateLimitHeaders(result: RateLimitResult): Record<string, string> {
-  return {
-    'X-RateLimit-Limit': String(MAX_REQUESTS),
-    'X-RateLimit-Remaining': String(Math.max(0, result.remaining)),
-    'Retry-After': String(Math.ceil(result.resetIn / 1000)),
-  };
+function namespacedKey(ip: string): string {
+  return `rl:${ip}`;
 }
 
 export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
-  const key = `ratelimit:llm-proxy:${ip}`;
-  // Atomic INCR; KV returns the new value. EXPIRE only on the first hit
-  // of the window so subsequent calls don't push the reset out.
-  const pipeline = kv.multi();
-  pipeline.incr(key);
-  pipeline.ttl(key);
-  const replies = (await pipeline.exec()) as [number | null, number | null];
+  const key = namespacedKey(ip);
+  const count = await kv.incr(key);
 
-  const count = typeof replies[0] === 'number' ? replies[0] : 0;
-  let ttl = typeof replies[1] === 'number' ? replies[1] : -1;
-
-  if (count === 1 || ttl < 0) {
-    await kv.expire(key, WINDOW_SECONDS);
-    ttl = WINDOW_SECONDS;
+  // Set TTL only on the first hit. Subsequent INCRs leave the expiry alone
+  // so the window stays fixed.
+  if (count === 1) {
+    await kv.pexpire(key, RATE_LIMIT_WINDOW_MS);
   }
 
-  const remaining = Math.max(0, MAX_REQUESTS - count);
-  const allowed = count <= MAX_REQUESTS;
-  return { allowed, remaining, resetIn: ttl * 1000 };
+  const pttl = await kv.pttl(key);
+
+  // -2 = key missing (shouldn't happen after a successful INCR, but defend
+  // against a race where the key was evicted between calls), -1 = no TTL.
+  // In both fall-throughs, treat as a full window remaining rather than
+  // panicking — the next call will set the TTL.
+  let resetIn: number;
+  if (pttl < 0) {
+    resetIn = RATE_LIMIT_WINDOW_MS;
+    if (count === 1 || pttl === -1) {
+      // First hit but TTL didn't stick (count === 1), or the key exists
+      // with a count > 1 but no TTL was ever set (pttl === -1). Either
+      // way, re-set the TTL so future requests see a proper window.
+      await kv.pexpire(key, RATE_LIMIT_WINDOW_MS);
+    }
+  } else {
+    resetIn = pttl;
+  }
+
+  const allowed = count <= RATE_LIMIT_MAX_REQUESTS;
+  const remaining = Math.max(0, RATE_LIMIT_MAX_REQUESTS - count);
+
+  return {
+    allowed,
+    remaining,
+    resetIn,
+    limit: RATE_LIMIT_MAX_REQUESTS,
+  };
+}
+
+// Standard rate-limit response headers. Single source of truth so the proxy
+// can return them on both the 429 path and the 2xx path.
+export function formatRateLimitHeaders(
+  result: RateLimitResult
+): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(result.limit),
+    'X-RateLimit-Remaining': String(result.remaining),
+    'X-RateLimit-Reset': String(Math.ceil(result.resetIn / 1000)),
+    ...(result.allowed
+      ? {}
+      : { 'Retry-After': String(Math.max(1, Math.ceil(result.resetIn / 1000))) }),
+  };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@vercel/kv": "^3.0.0",
         "dompurify": "^3.1.6",
         "html2canvas": "^1.4.1",
         "jspdf": "^3.0.1",
@@ -2490,11 +2491,33 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.2.tgz",
+      "integrity": "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/@vercel/edge": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
       "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
       "dev": true
+    },
+    "node_modules/@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@upstash/redis": "^1.34.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -9313,6 +9336,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -11284,11 +11313,27 @@
       "dev": true,
       "optional": true
     },
+    "@upstash/redis": {
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.2.tgz",
+      "integrity": "sha512-RZ+JaRCVIS+ZTGnjOnDMr+/0aqDxsBb5rV6aW+Pys4SGELwr5lwE3UbLHRCHqMQ5Ulxj0b/CFBHfbmE175Otog==",
+      "requires": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "@vercel/edge": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
       "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
       "dev": true
+    },
+    "@vercel/kv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+      "requires": {
+        "@upstash/redis": "^1.34.0"
+      }
     },
     "@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -16147,6 +16192,11 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
+    },
+    "uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/srikanthlogic/llm-wordsearch#readme",
   "dependencies": {
+    "@vercel/kv": "^3.0.0",
     "dompurify": "^3.1.6",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",

--- a/test/api/llm-proxy-rateLimit.test.ts
+++ b/test/api/llm-proxy-rateLimit.test.ts
@@ -21,6 +21,9 @@ vi.mock('../../api/llm-proxy/config', () => ({
 
 import { checkRateLimit, formatRateLimitHeaders } from '../../api/llm-proxy/rateLimit';
 
+const RATE_LIMIT = 15;
+const WINDOW = 60_000;
+
 describe('checkRateLimit (KV-backed)', () => {
   beforeEach(() => {
     mockIncr.mockReset();
@@ -30,18 +33,18 @@ describe('checkRateLimit (KV-backed)', () => {
 
   it('returns allowed=true with full remaining on a fresh key', async () => {
     mockIncr.mockResolvedValueOnce(1);
-    mockPexpire.mockResolvedValueOnce(1);
-    mockPttl.mockResolvedValueOnce(60_000);
+    mockPttl.mockResolvedValueOnce(WINDOW);
 
     const result = await checkRateLimit('1.1.1.1');
 
     expect(result).toEqual({
       allowed: true,
-      remaining: 14,
-      resetIn: 60_000,
+      remaining: RATE_LIMIT - 1,
+      resetIn: WINDOW,
+      limit: RATE_LIMIT,
     });
     expect(mockIncr).toHaveBeenCalledWith('rl:1.1.1.1');
-    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', 60_000);
+    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', WINDOW);
   });
 
   it('returns allowed=true with decremented remaining on increment within window', async () => {
@@ -52,50 +55,64 @@ describe('checkRateLimit (KV-backed)', () => {
 
     expect(result).toEqual({
       allowed: true,
-      remaining: 8,
+      remaining: RATE_LIMIT - 7,
       resetIn: 42_000,
+      limit: RATE_LIMIT,
     });
-    // pexpire should NOT be re-applied mid-window
+    // PEXPIRE is only called on the first hit of a window.
     expect(mockPexpire).not.toHaveBeenCalled();
   });
 
   it('returns allowed=false when count exceeds the cap', async () => {
-    mockIncr.mockResolvedValueOnce(16);
-    mockPttl.mockResolvedValueOnce(15_000);
+    mockIncr.mockResolvedValueOnce(RATE_LIMIT + 1);
+    mockPttl.mockResolvedValueOnce(10_000);
 
     const result = await checkRateLimit('1.1.1.1');
 
     expect(result).toEqual({
       allowed: false,
       remaining: 0,
-      resetIn: 15_000,
+      resetIn: 10_000,
+      limit: RATE_LIMIT,
     });
   });
 
   it('returns allowed=true with full remaining when counter is at the boundary', async () => {
-    mockIncr.mockResolvedValueOnce(15);
-    mockPttl.mockResolvedValueOnce(20_000);
+    mockIncr.mockResolvedValueOnce(RATE_LIMIT);
+    mockPttl.mockResolvedValueOnce(5_000);
 
     const result = await checkRateLimit('1.1.1.1');
 
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(0);
+    expect(result.resetIn).toBe(5_000);
   });
 
-  it('treats pttl=-1 (no TTL set) as full window', async () => {
-    mockIncr.mockResolvedValueOnce(1);
-    mockPexpire.mockResolvedValueOnce(1);
+  it('treats pttl=-1 (no TTL set) as full window and re-sets the TTL', async () => {
+    mockIncr.mockResolvedValueOnce(3);
     mockPttl.mockResolvedValueOnce(-1);
 
     const result = await checkRateLimit('1.1.1.1');
 
-    expect(result.allowed).toBe(true);
-    expect(result.resetIn).toBe(60_000);
+    // -1 means the key has no expiry, so we treat resetIn as a full window
+    // and try to set the TTL again (defensive: a previous pexpire may have
+    // been lost to a race or eviction).
+    expect(result.resetIn).toBe(WINDOW);
+    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', WINDOW);
   });
 
-  it('floors resetIn to 0 when pttl is non-positive', async () => {
-    mockIncr.mockResolvedValueOnce(16);
+  it('treats pttl=-2 (key missing) as full window', async () => {
+    mockIncr.mockResolvedValueOnce(3);
     mockPttl.mockResolvedValueOnce(-2);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result.resetIn).toBe(WINDOW);
+  });
+
+  it('returns resetIn=0 when pttl is exactly 0 (window just elapsed)', async () => {
+    mockIncr.mockResolvedValueOnce(5);
+    mockPttl.mockResolvedValueOnce(0);
 
     const result = await checkRateLimit('1.1.1.1');
 
@@ -104,12 +121,11 @@ describe('checkRateLimit (KV-backed)', () => {
 
   it('uses the IP as the namespacing key', async () => {
     mockIncr.mockResolvedValueOnce(1);
-    mockPexpire.mockResolvedValueOnce(1);
-    mockPttl.mockResolvedValueOnce(60_000);
+    mockPttl.mockResolvedValueOnce(WINDOW);
 
-    await checkRateLimit('203.0.113.42');
+    await checkRateLimit('203.0.113.7');
 
-    expect(mockIncr).toHaveBeenCalledWith('rl:203.0.113.42');
+    expect(mockIncr).toHaveBeenCalledWith('rl:203.0.113.7');
   });
 });
 
@@ -117,24 +133,36 @@ describe('formatRateLimitHeaders', () => {
   it('emits the standard rate-limit headers on allowed response', () => {
     const headers = formatRateLimitHeaders({
       allowed: true,
+      limit: RATE_LIMIT,
       remaining: 9,
       resetIn: 42_000,
     });
 
-    expect(headers['X-RateLimit-Limit']).toBe('15');
+    expect(headers['X-RateLimit-Limit']).toBe(String(RATE_LIMIT));
     expect(headers['X-RateLimit-Remaining']).toBe('9');
     expect(headers['X-RateLimit-Reset']).toBe('42');
     expect(headers['Retry-After']).toBeUndefined();
   });
 
-  it('includes Retry-After on rejected response, rounded up', () => {
+  it('includes Retry-After on rejected response, rounded up to at least 1', () => {
     const headers = formatRateLimitHeaders({
       allowed: false,
+      limit: RATE_LIMIT,
       remaining: 0,
       resetIn: 12_500,
     });
 
-    expect(headers['X-RateLimit-Remaining']).toBe('0');
     expect(headers['Retry-After']).toBe('13');
+  });
+
+  it('floors Retry-After to 1 when resetIn rounds down to 0', () => {
+    const headers = formatRateLimitHeaders({
+      allowed: false,
+      limit: RATE_LIMIT,
+      remaining: 0,
+      resetIn: 400,
+    });
+
+    expect(headers['Retry-After']).toBe('1');
   });
 });

--- a/test/api/llm-proxy-rateLimit.test.ts
+++ b/test/api/llm-proxy-rateLimit.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock @vercel/kv before importing the module under test
+const mockIncr = vi.fn();
+const mockPexpire = vi.fn();
+const mockPttl = vi.fn();
+
+vi.mock('@vercel/kv', () => ({
+  kv: {
+    incr: (...args: unknown[]) => mockIncr(...args),
+    pexpire: (...args: unknown[]) => mockPexpire(...args),
+    pttl: (...args: unknown[]) => mockPttl(...args),
+  },
+}));
+
+// Mock the config module so tests are deterministic
+vi.mock('../../api/llm-proxy/config', () => ({
+  RATE_LIMIT_WINDOW_MS: 60_000,
+  RATE_LIMIT_MAX_REQUESTS: 15,
+}));
+
+import { checkRateLimit, formatRateLimitHeaders } from '../../api/llm-proxy/rateLimit';
+
+describe('checkRateLimit (KV-backed)', () => {
+  beforeEach(() => {
+    mockIncr.mockReset();
+    mockPexpire.mockReset();
+    mockPttl.mockReset();
+  });
+
+  it('returns allowed=true with full remaining on a fresh key', async () => {
+    mockIncr.mockResolvedValueOnce(1);
+    mockPexpire.mockResolvedValueOnce(1);
+    mockPttl.mockResolvedValueOnce(60_000);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result).toEqual({
+      allowed: true,
+      remaining: 14,
+      resetIn: 60_000,
+    });
+    expect(mockIncr).toHaveBeenCalledWith('rl:1.1.1.1');
+    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', 60_000);
+  });
+
+  it('returns allowed=true with decremented remaining on increment within window', async () => {
+    mockIncr.mockResolvedValueOnce(7);
+    mockPttl.mockResolvedValueOnce(42_000);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result).toEqual({
+      allowed: true,
+      remaining: 8,
+      resetIn: 42_000,
+    });
+    // pexpire should NOT be re-applied mid-window
+    expect(mockPexpire).not.toHaveBeenCalled();
+  });
+
+  it('returns allowed=false when count exceeds the cap', async () => {
+    mockIncr.mockResolvedValueOnce(16);
+    mockPttl.mockResolvedValueOnce(15_000);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result).toEqual({
+      allowed: false,
+      remaining: 0,
+      resetIn: 15_000,
+    });
+  });
+
+  it('returns allowed=true with full remaining when counter is at the boundary', async () => {
+    mockIncr.mockResolvedValueOnce(15);
+    mockPttl.mockResolvedValueOnce(20_000);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(0);
+  });
+
+  it('treats pttl=-1 (no TTL set) as full window', async () => {
+    mockIncr.mockResolvedValueOnce(1);
+    mockPexpire.mockResolvedValueOnce(1);
+    mockPttl.mockResolvedValueOnce(-1);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result.allowed).toBe(true);
+    expect(result.resetIn).toBe(60_000);
+  });
+
+  it('floors resetIn to 0 when pttl is non-positive', async () => {
+    mockIncr.mockResolvedValueOnce(16);
+    mockPttl.mockResolvedValueOnce(-2);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result.resetIn).toBe(0);
+  });
+
+  it('uses the IP as the namespacing key', async () => {
+    mockIncr.mockResolvedValueOnce(1);
+    mockPexpire.mockResolvedValueOnce(1);
+    mockPttl.mockResolvedValueOnce(60_000);
+
+    await checkRateLimit('203.0.113.42');
+
+    expect(mockIncr).toHaveBeenCalledWith('rl:203.0.113.42');
+  });
+});
+
+describe('formatRateLimitHeaders', () => {
+  it('emits the standard rate-limit headers on allowed response', () => {
+    const headers = formatRateLimitHeaders({
+      allowed: true,
+      remaining: 9,
+      resetIn: 42_000,
+    });
+
+    expect(headers['X-RateLimit-Limit']).toBe('15');
+    expect(headers['X-RateLimit-Remaining']).toBe('9');
+    expect(headers['X-RateLimit-Reset']).toBe('42');
+    expect(headers['Retry-After']).toBeUndefined();
+  });
+
+  it('includes Retry-After on rejected response, rounded up', () => {
+    const headers = formatRateLimitHeaders({
+      allowed: false,
+      remaining: 0,
+      resetIn: 12_500,
+    });
+
+    expect(headers['X-RateLimit-Remaining']).toBe('0');
+    expect(headers['Retry-After']).toBe('13');
+  });
+});


### PR DESCRIPTION
Replaces the in-memory `rateLimits` Map (per-edge-instance, lost on cold start) with `@vercel/kv` so the 15 req/min cap is enforced globally.

**Implementation**
- New `api/llm-proxy/config.ts` — single source of truth for `RATE_LIMIT_WINDOW_MS` and `RATE_LIMIT_MAX_REQUESTS`.
- New `api/llm-proxy/rateLimit.ts` — atomic INCR + pexpire on first hit, repair TTL when pttl is -1, return `{allowed, limit, remaining, resetIn}`.
- `api/llm-proxy/index.ts` — call site now uses the new helper, response headers via `formatRateLimitHeaders` (X-RateLimit-Limit/Remaining/Reset + Retry-After when rejected).
- Drops the dead `LLMProxyRequest` interface (validate.ts owns the contract).

**Setup required after merge**
Provision a Vercel KV store and add `KV_URL` + `KV_REST_API_TOKEN` to the project env. Until then, the proxy logs a warning and falls back to allowing all requests — so the existing community flow continues to work, just without global limits.

**Tests**
11 new unit tests for `checkRateLimit` and `formatRateLimitHeaders`: fresh key, increment, cap, boundary, pttl=-1 (TTL repair), pttl=-2 (key missing), pttl=0, namespacing, header shape, Retry-After rounding. All pass locally; 257 total tests green.