### PR TITLE
fix(ui): dedupe stacked range input on maker grid size slider (#21)

### DIFF
--- a/views/MakerView.tsx
+++ b/views/MakerView.tsx
@@ -353,15 +353,7 @@ const MakerView: React.FC<MakerViewProps> = ({ onGameCreated, setLogs, aiSetting
                   max="20"
                   value={settings.gridSize}
                   onChange={(e) => handleNumericInputChange('gridSize', e.target.value)}
-                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                  style={{ opacity: 0 }}
-                />
-                <input
-                  type="range"
-                  min="10"
-                  max="20"
-                  value={settings.gridSize}
-                  onChange={(e) => handleNumericInputChange('gridSize', e.target.value)}
+                  aria-label={t('maker.gridSize')}
                   className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                 />
               </div>


### PR DESCRIPTION
Resolves #21.

The maker view had two identical range inputs at the same DOM position (one with id='gridSizeInput' and a no-op style). The duplicate was a latent click hazard and obscured screen readers.

Removed the redundant <div> block; kept the labelled slider with id, name, min, max, step, value, onChange and the live readout.