### PR TITLE
fix(ai): dedupe duplicate words within each generated level (#24)

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -56,12 +56,19 @@ const sanitizeWords = (levels: LevelWords[]): Word[][] => {
   }
   const sanitizedLevels = sanitizeLLMResponse(levels);
   const sortedLevels = sanitizedLevels.sort((a, b) => a.level - b.level);
-  return sortedLevels.map(levelData =>
-    levelData.words.map(w => ({
+  return sortedLevels.map(levelData => {
+    const seenWords = new Set<string>();
+    return levelData.words.map(w => ({
       ...w,
       word: w.word.replace(/\s+/g, '').toUpperCase()
-    })).filter(w => w.word.length > 0)
-  );
+    }))
+      .filter(w => w.word.length > 0)
+      .filter(w => {
+        if (seenWords.has(w.word)) return false;
+        seenWords.add(w.word);
+        return true;
+      });
+  });
 };
 
 // This function is now the single point of contact for any OpenAI-compatible API.

--- a/test/services/geminiService.test.ts
+++ b/test/services/geminiService.test.ts
@@ -263,6 +263,75 @@ describe('GeminiService', () => {
       ]);
     });
 
+    it('dedupes duplicate words within a level (#24)', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                levels: [{
+                  level: 1,
+                  words: [
+                    { word: 'CAT', hint: 'First cat' },
+                    { word: 'cat', hint: 'Duplicate, case variant' },
+                    { word: 'c at', hint: 'Duplicate with space' },
+                    { word: 'DOG', hint: 'Unique' }
+                  ]
+                }]
+              })
+            }
+          }]
+        })
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const result = await generateGameLevels({
+        theme: 'test',
+        wordCount: 2,
+        levelCount: 1,
+        onLog: vi.fn(),
+        aiSettings: { provider: AIProvider.Community },
+        language: 'en'
+      });
+
+      expect(result[0]).toEqual([
+        { word: 'CAT', hint: 'First cat' },
+        { word: 'DOG', hint: 'Unique' }
+      ]);
+    });
+
+    it('keeps identical words across different levels (#24)', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                levels: [
+                  { level: 1, words: [{ word: 'CAT', hint: 'Level one cat' }] },
+                  { level: 2, words: [{ word: 'CAT', hint: 'Level two cat' }] }
+                ]
+              })
+            }
+          }]
+        })
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const result = await generateGameLevels({
+        theme: 'test',
+        wordCount: 1,
+        levelCount: 2,
+        onLog: vi.fn(),
+        aiSettings: { provider: AIProvider.Community },
+        language: 'en'
+      });
+
+      expect(result[0]).toEqual([{ word: 'CAT', hint: 'Level one cat' }]);
+      expect(result[1]).toEqual([{ word: 'CAT', hint: 'Level two cat' }]);
+    });
+
     it('should apply language-specific model overrides', async () => {
       // Set up language map in environment
       const originalLanguageMap = process.env.LANGUAGE_MODEL_MAP;


### PR DESCRIPTION
## Problem
`handleWordFound` in PlayerView matches by word text, so if an AI-generated level contains the same word twice, one swipe flips every copy to found.

## Fix
Dedupe at generation time — the sanitize pipeline (`sanitizeWords`) now collapses duplicate words **within each level**, after normalization (whitespace stripped, uppercased), keeping the first occurrence's hint. Identical words across *different* levels are preserved.

## Tests
- dedupes `CAT` / `cat` / `c at` → single `CAT` (#24)
- keeps identical words across levels 1 and 2 (#24)

Closes #24