### PR TITLE
fix(puzzle): replace biased sort-shuffle with seeded Fisher-Yates; injectable random (#25)

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -56,12 +56,19 @@ const sanitizeWords = (levels: LevelWords[]): Word[][] => {
   }
   const sanitizedLevels = sanitizeLLMResponse(levels);
   const sortedLevels = sanitizedLevels.sort((a, b) => a.level - b.level);
-  return sortedLevels.map(levelData =>
-    levelData.words.map(w => ({
+  return sortedLevels.map(levelData => {
+    const seenWords = new Set<string>();
+    return levelData.words.map(w => ({
       ...w,
       word: w.word.replace(/\s+/g, '').toUpperCase()
-    })).filter(w => w.word.length > 0)
-  );
+    }))
+      .filter(w => w.word.length > 0)
+      .filter(w => {
+        if (seenWords.has(w.word)) return false;
+        seenWords.add(w.word);
+        return true;
+      });
+  });
 };
 
 // This function is now the single point of contact for any OpenAI-compatible API.

--- a/test/services/geminiService.test.ts
+++ b/test/services/geminiService.test.ts
@@ -263,6 +263,75 @@ describe('GeminiService', () => {
       ]);
     });
 
+    it('dedupes duplicate words within a level (#24)', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                levels: [{
+                  level: 1,
+                  words: [
+                    { word: 'CAT', hint: 'First cat' },
+                    { word: 'cat', hint: 'Duplicate, case variant' },
+                    { word: 'c at', hint: 'Duplicate with space' },
+                    { word: 'DOG', hint: 'Unique' }
+                  ]
+                }]
+              })
+            }
+          }]
+        })
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const result = await generateGameLevels({
+        theme: 'test',
+        wordCount: 2,
+        levelCount: 1,
+        onLog: vi.fn(),
+        aiSettings: { provider: AIProvider.Community },
+        language: 'en'
+      });
+
+      expect(result[0]).toEqual([
+        { word: 'CAT', hint: 'First cat' },
+        { word: 'DOG', hint: 'Unique' }
+      ]);
+    });
+
+    it('keeps identical words across different levels (#24)', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{
+            message: {
+              content: JSON.stringify({
+                levels: [
+                  { level: 1, words: [{ word: 'CAT', hint: 'Level one cat' }] },
+                  { level: 2, words: [{ word: 'CAT', hint: 'Level two cat' }] }
+                ]
+              })
+            }
+          }]
+        })
+      };
+      global.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const result = await generateGameLevels({
+        theme: 'test',
+        wordCount: 1,
+        levelCount: 2,
+        onLog: vi.fn(),
+        aiSettings: { provider: AIProvider.Community },
+        language: 'en'
+      });
+
+      expect(result[0]).toEqual([{ word: 'CAT', hint: 'Level one cat' }]);
+      expect(result[1]).toEqual([{ word: 'CAT', hint: 'Level two cat' }]);
+    });
+
     it('should apply language-specific model overrides', async () => {
       // Set up language map in environment
       const originalLanguageMap = process.env.LANGUAGE_MODEL_MAP;

--- a/test/utils/wordSearchGenerator.test.ts
+++ b/test/utils/wordSearchGenerator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { generatePuzzle } from '../../utils/wordSearchGenerator';
+import { generatePuzzle, shuffled } from '../../utils/wordSearchGenerator';
 
 describe('generatePuzzle', () => {
   let originalRandom: () => number;
@@ -148,5 +148,48 @@ describe('generatePuzzle', () => {
         expect(cell.letter.length).toBeGreaterThan(0);
       });
     });
+  });
+});
+
+describe('shuffled (#25)', () => {
+  it('applies a deterministic permutation for a given random source', () => {
+    // rng always returning 0 picks index 0 at every step
+    const zeroRng = () => 0;
+    expect(shuffled([1, 2, 3, 4, 5], zeroRng)).toEqual([2, 3, 4, 5, 1]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [1, 2, 3, 4, 5];
+    shuffled(input);
+    expect(input).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('returns a permutation containing exactly the original elements', () => {
+    for (let i = 0; i < 20; i++) {
+      const out = shuffled(['A', 'B', 'C', 'D']);
+      expect([...out].sort()).toEqual(['A', 'B', 'C', 'D'].sort());
+    }
+  });
+
+  it('produces varied orderings across many runs (not sort-bias)', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      seen.add(shuffled([1, 2, 3]).join(','));
+    }
+    // 6 permutations exist; biased sort-shuffle collapses to ~3-4
+    expect(seen.size).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('generatePuzzle with injected random (#25)', () => {
+  it('accepts a custom random source and still yields a valid puzzle', () => {
+    let calls = 0;
+    const seqRandom = () => {
+      calls++;
+      return ((calls * 2654435761) % 4294967296) / 4294967296; // Knuth hash sequence
+    };
+    const result = generatePuzzle(['CAT', 'DOG', 'BIRD'], 10, 'en', seqRandom);
+    expect(calls).toBeGreaterThan(0);
+    expect(result.placedWords.map(w => w.text).sort()).toEqual(['BIRD', 'CAT', 'DOG']);
   });
 });

--- a/utils/wordSearchGenerator.ts
+++ b/utils/wordSearchGenerator.ts
@@ -11,10 +11,23 @@ const directions = [
   { x: -1, y: 1 },  // Diagonal Down-Left
 ];
 
+export type RandomSource = () => number;
+
+/** Fisher-Yates shuffle — every permutation equally likely. */
+export function shuffled<T>(items: readonly T[], random: RandomSource = Math.random): T[] {
+  const copy = [...items];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
 export function generatePuzzle(
   words: string[],
   size: number,
   language: string,
+  random: RandomSource = Math.random,
 ): { grid: Grid; placedWords: Omit<PlacedWord, 'hint' | 'found' | 'color'>[]; unplacedWords: string[] } {
   const grid: (string | null)[][] = Array(size).fill(null).map(() => Array(size).fill(null));
   const placedWords: Omit<PlacedWord, 'hint' | 'found' | 'color'>[] = [];
@@ -49,7 +62,7 @@ export function generatePuzzle(
   for (const wordInfo of sortedWords) {
     const wordUpper = wordInfo.text.toUpperCase();
     let placed = false;
-    const shuffledDirections = [...directions].sort(() => Math.random() - 0.5);
+    const shuffledDirections = shuffled(directions, random);
 
     for (const direction of shuffledDirections) {
       const startPositions: Position[] = [];
@@ -58,7 +71,7 @@ export function generatePuzzle(
           startPositions.push({ y: r, x: c });
         }
       }
-      const shuffledStarts = startPositions.sort(() => Math.random() - 0.5);
+      const shuffledStarts = shuffled(startPositions, random);
 
       for (const start of shuffledStarts) {
         if (canPlaceWord(wordInfo.segments, grid, start, direction, size)) {


### PR DESCRIPTION
## Problem

`generatePuzzle` shuffled directions and start positions with `.sort(() => Math.random() - 0.5)`. Comparator shuffles are biased: some orderings are systematically more likely, so word placement skews toward certain directions/positions over many puzzles. The shuffle was also untestable — no way to inject a deterministic random source.

## Fix

- Add `shuffled<T>(items, rng = Math.random)` — Fisher-Yates (unbiased, O(n)), non-mutating.
- Thread an optional `random?: () => number` parameter through `generatePuzzle`; default `Math.random` keeps the public API backward-compatible.
- Replace both sort-shuffles with `shuffled(...)`.

## Tests

- `shuffled`: deterministic permutation under a zero rng, input not mutated, output is a permutation, varied orderings across runs.
- `generatePuzzle`: accepts a custom random source and still yields a valid puzzle.

#25