### PR TITLE
fix(rate-limit): re-arm TTL on any missing-TTL observation (#19 follow-up)

### DIFF
--- a/api/llm-proxy/rateLimit.ts
+++ b/api/llm-proxy/rateLimit.ts
@@ -60,12 +60,11 @@ export async function checkRateLimit(ip: string): Promise<RateLimitResult> {
   let resetIn: number;
   if (pttl < 0) {
     resetIn = RATE_LIMIT_WINDOW_MS;
-    if (count === 1 || pttl === -1) {
-      // First hit but TTL didn't stick (count === 1), or the key exists
-      // with a count > 1 but no TTL was ever set (pttl === -1). Either
-      // way, re-set the TTL so future requests see a proper window.
-      await kv.pexpire(key, RATE_LIMIT_WINDOW_MS);
-    }
+    // The key has no usable TTL: it is missing (-2, e.g. evicted between
+    // INCR and PTTL) or exists without an expiry (-1). Re-arm it on every
+    // such observation so the window can never become immortal — a counter
+    // with count > 1 and no TTL would block the IP forever once capped.
+    await kv.pexpire(key, RATE_LIMIT_WINDOW_MS);
   } else {
     resetIn = pttl;
   }

--- a/test/api/llm-proxy-rateLimit.test.ts
+++ b/test/api/llm-proxy-rateLimit.test.ts
@@ -119,6 +119,27 @@ describe('checkRateLimit (KV-backed)', () => {
     expect(result.resetIn).toBe(0);
   });
 
+  it('re-sets the TTL when pttl=-2 with count>1 (evicted-key race)', async () => {
+    mockIncr.mockResolvedValueOnce(3);
+    mockPttl.mockResolvedValueOnce(-2);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    expect(result.resetIn).toBe(WINDOW);
+    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', WINDOW);
+  });
+
+  it('sets the TTL on the very first hit even when pttl reports -1', async () => {
+    mockIncr.mockResolvedValueOnce(1);
+    mockPttl.mockResolvedValueOnce(-1);
+
+    const result = await checkRateLimit('1.1.1.1');
+
+    // First hit already ran pexpire; the pttl=-1 branch must not skip it.
+    expect(mockPexpire).toHaveBeenCalledWith('rl:1.1.1.1', WINDOW);
+    expect(result.resetIn).toBe(WINDOW);
+  });
+
   it('uses the IP as the namespacing key', async () => {
     mockIncr.mockResolvedValueOnce(1);
     mockPttl.mockResolvedValueOnce(WINDOW);


### PR DESCRIPTION
Follow-up hardening of the #19 KV rate limiter.

**Bug:** If the counter key was evicted between INCR and PTTL (pttl === -2), or existed without an expiry, the old code only re-armed TTL when `count === 1 || pttl === -1`. A count > 1 key with no TTL would cap the IP **permanently** — an immortal rate-limit window.

**Fix:** Re-arm `pexpire` on every missing-TTL observation (-1 or -2).

**Tests:** added cases for evicted-key (-2) and lost-expiry (-1) paths.