### PR TITLE
perf(maker): batch level generation into one AI request (#26)

### DIFF
--- a/test/views/MakerView.test.tsx
+++ b/test/views/MakerView.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AIProvider } from '../../types';
+import type { Word, AIProviderSettings } from '../../types';
+import MakerView from '../../views/MakerView';
+
+const generateGameLevelsMock = vi.fn();
+vi.mock('../../services/geminiService', () => ({
+  generateGameLevels: (...args: unknown[]) => generateGameLevelsMock(...args),
+}));
+
+vi.mock('../../hooks/useI18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../components/LanguageSelector', () => ({ default: () => null }));
+
+const aiSettings: AIProviderSettings = { provider: AIProvider.Community };
+
+const words = (prefix: string, count: number): Word[] =>
+  Array.from({ length: count }, (_, i) => ({ word: `${prefix}${i}`, hint: `hint ${i}` }));
+
+const renderMaker = () =>
+  render(
+    <MakerView
+      onGameCreated={vi.fn()}
+      setLogs={vi.fn()}
+      aiSettings={aiSettings}
+    />
+  );
+
+describe('MakerView level generation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateGameLevelsMock.mockResolvedValue([words('A', 5)]);
+  });
+
+  it('requests all levels in one batched call', async () => {
+    generateGameLevelsMock.mockResolvedValue([words('A', 5), words('B', 5)]);
+
+    renderMaker();
+    fireEvent.change(screen.getByLabelText('maker.levelsLabel'), { target: { value: '2' } });
+    fireEvent.change(screen.getByLabelText('maker.themeLabel'), { target: { value: 'space' } });
+    fireEvent.click(screen.getByRole('button', { name: /maker\.generateButton/i }));
+
+    await waitFor(() => {
+      expect(generateGameLevelsMock).toHaveBeenCalledTimes(1);
+    });
+    expect(generateGameLevelsMock).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: 'space', levelCount: 2 })
+    );
+  });
+
+  it('tops up missing levels with follow-up single-level calls', async () => {
+    generateGameLevelsMock
+      .mockResolvedValueOnce([words('A', 5)])
+      .mockResolvedValue([words('B', 5)]);
+
+    renderMaker();
+    fireEvent.change(screen.getByLabelText('maker.levelsLabel'), { target: { value: '3' } });
+    fireEvent.change(screen.getByLabelText('maker.themeLabel'), { target: { value: 'space' } });
+    fireEvent.click(screen.getByRole('button', { name: /maker\.generateButton/i }));
+
+    await waitFor(() => {
+      expect(generateGameLevelsMock).toHaveBeenCalledTimes(3);
+    });
+    expect(generateGameLevelsMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ levelCount: 3 })
+    );
+    expect(generateGameLevelsMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ levelCount: 1 })
+    );
+    expect(generateGameLevelsMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ levelCount: 1 })
+    );
+  });
+});

--- a/views/MakerView.tsx
+++ b/views/MakerView.tsx
@@ -47,29 +47,49 @@ const MakerView: React.FC<MakerViewProps> = ({ onGameCreated, setLogs, aiSetting
         const log = (entry: AILogEntry) => setLogs(prev => [...prev, entry]);
 
         try {
-            const allGeneratedWords: Word[][] = [];
-            for (let i = 0; i < newSettings.levelCount; i++) {
-                log({
-                  id: `level-${i + 1}`,
-                  timestamp: new Date(),
-                  type: AILogType.Info,
-                  status: AILogStatus.InProgress,
-                  message: `--- Generating Level ${i + 1} of ${newSettings.levelCount} ---`,
-                });
-                const singleLevelWords = await generateGameLevels({
+            // Single batched request for all levels - avoids chained requests
+            // that risk proxy rate limits (429) mid-generation (#26).
+            log({
+              id: 'level-batch',
+              timestamp: new Date(),
+              type: AILogType.Info,
+              status: AILogStatus.InProgress,
+              message: `--- Generating ${newSettings.levelCount} level(s) in one AI request ---`,
+            });
+            let allGeneratedWords: Word[][] = (
+                await generateGameLevels({
                     theme: newSettings.theme,
                     wordCount: newSettings.wordCount,
-                    levelCount: 1,
+                    levelCount: newSettings.levelCount,
                     language: newSettings.language,
                     onLog: log,
                     aiSettings,
+                })
+            ).filter(levelWords => levelWords.length > 0);
+
+            if (allGeneratedWords.length < newSettings.levelCount) {
+                const missing = newSettings.levelCount - allGeneratedWords.length;
+                log({
+                  id: 'level-topup',
+                  timestamp: new Date(),
+                  type: AILogType.Warning,
+                  status: AILogStatus.InProgress,
+                  message: `Batched generation returned ${allGeneratedWords.length}/${newSettings.levelCount} levels. Falling back to ${missing} sequential request(s).`,
                 });
-
-                if (singleLevelWords.length === 0 || singleLevelWords[0].length === 0) {
-                    throw new Error(`AI failed to generate words for level ${i + 1}.`);
+                for (let i = 0; i < missing; i++) {
+                    const topUp = await generateGameLevels({
+                        theme: newSettings.theme,
+                        wordCount: newSettings.wordCount,
+                        levelCount: 1,
+                        language: newSettings.language,
+                        onLog: log,
+                        aiSettings,
+                    });
+                    if (topUp.length === 0 || topUp[0].length === 0) {
+                        throw new Error(`AI failed to generate words for level ${allGeneratedWords.length + 1}.`);
+                    }
+                    allGeneratedWords.push(topUp[0]);
                 }
-
-                allGeneratedWords.push(singleLevelWords[0]);
             }
 
             if (allGeneratedWords.length === 0) throw new Error("AI failed to generate any words. Check the AI Log in Settings for details.");


### PR DESCRIPTION
Closes #26

- MakerView now requests all N levels in a single LLM call (prompt already supports a levels array) instead of N chained sequential calls that risked 429s against the 15/min proxy limit.
- If the batch returns fewer usable levels than requested, falls back to sequential single-level top-up for only the missing count.
- Tests: new `test/views/MakerView.test.tsx` covers the batched call shape and the fallback path.

Verified locally: type-check ✅ lint 0 errors ✅ 280 tests pass ✅ build ✅